### PR TITLE
Transforms target language to DeepL language code

### DIFF
--- a/src/commands/DeepLTranslatorCommand.php
+++ b/src/commands/DeepLTranslatorCommand.php
@@ -93,7 +93,7 @@ class DeepLTranslatorCommand extends Command {
 
 			// Read params
 			$force = (bool) $input->getOption('force');
-			$to = (string) ($input->getOption('to') ?? basename($inputFile, '.po'));
+			$to = (string) str_replace('_', '-', $input->getOption('to') ?? basename($inputFile, '.po'));
 			$from = (string) $input->getOption('from');
 			$wait = (int) $input->getOption('wait');
 


### PR DESCRIPTION
Target languages derived from files can contain an underscore character but DeepL requires a dash character for separating language and country