### PR TITLE
Add --ignore option to DeepLTranslatorCommand

### DIFF
--- a/src/translator/DeepLTranslator.php
+++ b/src/translator/DeepLTranslator.php
@@ -7,21 +7,28 @@ use Gettext\Translation;
 class DeepLTranslator extends TranslatorAbstract {
 
 	private \DeepL\Translator $translator;
+	private ?string $regex;
 
-	public function __construct(\DeepL\Translator $translator) {
+	public function __construct(\DeepL\Translator $translator, string $regex = null) {
 		$this->translator = $translator;
+		$this->regex = $regex;
 	}
 
 	/**
 	 * @throws \DeepL\DeepLException
 	 */
 	public function getTranslation(Translation $sentence): string {
+		$text = $sentence->getOriginal();
 		$response = $this->translator->translateText(
-			$sentence->getOriginal(),
+			$this->regex ? preg_replace('/(' . $this->regex . ')/', '<keep>$1</keep>', $text) : $text,
 			$this->from,
 			$this->to,
+			[
+				'tag_handling' => 'xml',
+				'ignore_tags' => 'keep',
+			]
 		);
 
-		return $response->text;
+		return preg_replace('/<\/?keep>/i', '', $response->text);
 	}
 }


### PR DESCRIPTION
Adds --ignore option with a regular expression value to keep matched text as is without translating it trough DeepL, e.g. `--ignore="\"?%[0-9]+\\\$[sdf]\"?"` to keep placeholders like `%1$s`. This is a generalized approach of the DeepLTranslatorEscaped class