### PR TITLE
Add option for POT file to map source strings

### DIFF
--- a/src/commands/DeepLTranslatorCommand.php
+++ b/src/commands/DeepLTranslatorCommand.php
@@ -29,6 +29,7 @@ class DeepLTranslatorCommand extends Command {
 			->addOption('force', null, InputOption::VALUE_NONE, 'Force re-translate including translated sentences')
 			->addOption('ignore', null, InputOption::VALUE_REQUIRED, 'Regular expression to ignore parts of the text', null)
 			->addOption('only', null, InputOption::VALUE_NONE, 'Create only PO file, no MO file')
+			->addOption('pot', null, InputOption::VALUE_REQUIRED, 'POT file path for mapping translations', null)
 			->addOption('wait', null, InputOption::VALUE_REQUIRED, 'Wait between translations in milliseconds', false)
 			->addOption('apikey', null, InputOption::VALUE_REQUIRED, 'Deepl API Key')
 			->addOption('translator', null, InputOption::VALUE_OPTIONAL, 'Path to custom translator instance', null)
@@ -65,6 +66,16 @@ class DeepLTranslatorCommand extends Command {
 				throw new InvalidOptionException('Invalid directory path: ' . $outputDir);
 			}
 
+			// Input POT file
+			$potTrans = null;
+			if ($potFile = $input->getOption('pot')) {
+				if ($potFile[0] !== '/') {
+					$potFile = $dir . '/' . $potFile;
+				}
+
+				$potTrans = (new \Gettext\Loader\PoLoader())->loadFile($potFile);
+			}
+
 			// Get API key from .env or command line
 			$apikey = $_ENV['DEEPL_API_KEY'] ?? $input->getOption('apikey');
 
@@ -83,6 +94,7 @@ class DeepLTranslatorCommand extends Command {
 			} else {
 				$translator = new DeepLTranslator(
 					new Translator($apikey),
+					$potTrans,
 					$input->getOption('ignore')
 				);
 			}

--- a/src/translator/DeepLTranslator.php
+++ b/src/translator/DeepLTranslator.php
@@ -7,18 +7,20 @@ use Gettext\Translation;
 class DeepLTranslator extends TranslatorAbstract {
 
 	private \DeepL\Translator $translator;
+	private ?\Gettext\Translations $pot;
 	private ?string $regex;
 
-	public function __construct(\DeepL\Translator $translator, string $regex = null) {
+	public function __construct(\DeepL\Translator $translator, \Gettext\Translations $pot = null, string $regex = null) {
 		$this->translator = $translator;
 		$this->regex = $regex;
+		$this->pot = $pot;
 	}
 
 	/**
 	 * @throws \DeepL\DeepLException
 	 */
 	public function getTranslation(Translation $sentence): string {
-		$text = $sentence->getOriginal();
+		$text = $this->pot?->find($sentence->getContext(), $sentence->getOriginal())?->getTranslation() ?: $sentence->getOriginal();
 		$response = $this->translator->translateText(
 			$this->regex ? preg_replace('/(' . $this->regex . ')/', '<keep>$1</keep>', $text) : $text,
 			$this->from,


### PR DESCRIPTION
Translation tools use translations in the POT files to display them as source for PO translations to different languages. This PR maps the PO file msgid to the POT file msgstr like these tools do. Example:

POT msgid="cz"
POT msgstr="Czech"
PO msgid="cz"

-> String sent to DeepL for translation: "Czech"