### PR TITLE
Enhance translation handling with htmlentities decoding

### DIFF
--- a/src/translator/DeepLTranslator.php
+++ b/src/translator/DeepLTranslator.php
@@ -25,6 +25,7 @@ class DeepLTranslator extends TranslatorAbstract {
 	 */
 	public function getTranslation(Translation $sentence): string {
 		$text = $this->pot?->find($sentence->getContext(), $sentence->getOriginal())?->getTranslation() ?: $sentence->getOriginal();
+		$text = htmlentities($text, ENT_SUBSTITUTE, 'UTF-8');
 		$response = $this->translator->translateText(
 			$this->regex ? preg_replace('/(' . $this->regex . ')/', '<keep>$1</keep>', $text) : $text,
 			$this->from,
@@ -35,6 +36,6 @@ class DeepLTranslator extends TranslatorAbstract {
 			]
 		);
 
-		return preg_replace('/<\/?keep>/i', '', $response->text);
+		return html_entity_decode(preg_replace('/<\/?keep>/i', '', $response->text), ENT_SUBSTITUTE, 'UTF-8');
 	}
 }


### PR DESCRIPTION
Without encoding/decoding special characters like `<` and `>`, translation fails when using escaped sequences that contains these characters