### PR TITLE
Handle translation exceptions in PoTranslator

### DIFF
--- a/src/PoTranslator.php
+++ b/src/PoTranslator.php
@@ -72,15 +72,22 @@ class PoTranslator {
 
 				if (!$translation->isHit()) {
 
-					$translation->set(
-						$this->translator
-							->from($from)
-							->to($to)
-							->getTranslation($sentence)
-					);
+					try {
+						$translation->set(
+							$this->translator
+								->from($from)
+								->to($to)
+								->getTranslation($sentence)
+						);
 
-					// save cache
-					$this->cache->save($translation);
+						// save cache
+						$this->cache->save($translation);
+					} catch (\DeepL\TooManyRequestsException $e) {
+						sleep(1);
+						continue;
+					} catch (\DeepL\DeepLException $e) {
+						continue;
+					}
 				}
 
 				$sentence->translate($translation->get());


### PR DESCRIPTION
If DeepL returns an error (e.g. HTTP status 429), all translations already fetched are lost.